### PR TITLE
Add signal reporting to ucc interpreter -- fixes CTRL-C issue on Windows

### DIFF
--- a/ucci/src/main.rs
+++ b/ucci/src/main.rs
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use linefeed::{Interface, ReadResult};
+use linefeed::{Interface, ReadResult, Signal};
 use std::error::Error;
 use std::io::stdout;
 use ucc::interp::Interp;
@@ -16,6 +16,14 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("Type \":help\" to see the available commands.");
     let reader = Interface::new("ucci")?;
     reader.set_prompt("\n>>> ")?;
+
+    // Report all signals
+    reader.set_report_signal(Signal::Break, true);
+    reader.set_report_signal(Signal::Continue, true);
+    reader.set_report_signal(Signal::Interrupt, true);
+    reader.set_report_signal(Signal::Suspend, true);
+    reader.set_report_signal(Signal::Quit, true);
+    
     while let ReadResult::Input(input) = reader.read_line()? {
         reader.add_history(input.clone());
         interp.interp_start(input.as_str(), &mut stdout()).unwrap();


### PR DESCRIPTION
On Windows, there is no way to quit the interpreter. This at least allows the CTRL-C to flow through to the application rather than just echoing "^C" in the console.